### PR TITLE
Try-Catch Importing the Tagger

### DIFF
--- a/unigram_tagger_model_trainer.py
+++ b/unigram_tagger_model_trainer.py
@@ -36,13 +36,18 @@ def generate_tagger():
     return unigram_tagger
 
 def import_tagger():
-    import dill
-    import os
+    try:
+        import dill
+        import os
 
-    # noinspection PyBroadException
-    #try:
-    with open(f'{os.path.dirname(__file__)}/{tagger_file}', 'rb') as fin:
-        return dill.load(fin)
+        # noinspection PyBroadException
+        #try:
+        with open(f'{os.path.dirname(__file__)}/{tagger_file}', 'rb') as fin:
+            return dill.load(fin)
+    # pickling doesn't work in the WASM version of CPython, prevent dill loading errors from borking the web translator.
+    #     ~ HSI
+    except ModuleNotFoundError:
+        return None
     #except:
         #return None
 


### PR DESCRIPTION
the Emscripten version of CPython doesn't support pickling, which is used for loading and saving the Unigram Tagger Pickle.

If we can't load dill at runtime, fallback to generating the tagger at runtime.

This isn't a solution for other problems, just for the module "multiprocessing", but will prevent it from crashing completely.